### PR TITLE
Allow use of a custom PAGER, add Windows support for pager

### DIFF
--- a/command.php
+++ b/command.php
@@ -197,14 +197,8 @@ class Doc_Command {
 
 
 	private static function pass_through_pager( $out ) {
-		if ( strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN' ) {
-			// no paging for Windows cmd.exe; sorry
-			echo $out;
-			return 0;
-		}
-
 		if ( false === ( $pager = getenv( 'PAGER' ) ) ) {
-			$pager = 'less -r';
+			$pager = WP_CLI\Utils\is_windows() ? 'more' : 'less -r';
 		}
 
 		// convert string to file handle

--- a/command.php
+++ b/command.php
@@ -203,6 +203,10 @@ class Doc_Command {
 			return 0;
 		}
 
+		if ( false === ( $pager = getenv( 'PAGER' ) ) ) {
+			$pager = 'less -r';
+		}
+
 		// convert string to file handle
 		$fd = fopen( "php://temp", "r+" );
 		fputs( $fd, $out );
@@ -214,7 +218,7 @@ class Doc_Command {
 			2 => STDERR
 		);
 
-		return proc_close( proc_open( 'less -r', $descriptorspec, $pipes ) );
+		return proc_close( proc_open( $pager, $descriptorspec, $pipes ) );
 	}
 
 }


### PR DESCRIPTION
This PR allows the use of a custom pager set by the `$PAGER` environment flag. If none is set, it falls back to `less -r`.

It also adds Windows support for using a pager.
