### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "alleyinteractive/wp-doc-command",
     "description": "View PHPDoc of any class, method, property, or function.",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/alleyinteractive/wp-doc-command",
     "support": {
         "issues": "https://github.com/alleyinteractive/wp-doc-command"


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
